### PR TITLE
squid:UselessParenthesesCheck - Useless parentheses around expression…

### DIFF
--- a/src/main/java/org/cf/resequencer/Options.java
+++ b/src/main/java/org/cf/resequencer/Options.java
@@ -357,7 +357,7 @@ public class Options {
     public static void showUsage() {
         String jarName;
         try {
-            File f = new File((org.cf.resequencer.Main.class.getProtectionDomain().getCodeSource().getLocation().toURI()));
+            File f = new File(org.cf.resequencer.Main.class.getProtectionDomain().getCodeSource().getLocation().toURI());
             jarName = f.getName();
         } catch (URISyntaxException ex) {
             jarName = "sequencer.jar";

--- a/src/main/java/org/cf/resequencer/patch/SmaliFile.java
+++ b/src/main/java/org/cf/resequencer/patch/SmaliFile.java
@@ -38,7 +38,7 @@ public class SmaliFile {
                 return false;
             }
 
-            return (o.hashCode() == hashCode());
+            return o.hashCode() == hashCode();
         }
 
         @Override
@@ -257,7 +257,7 @@ public class SmaliFile {
                 // FileLines = FileLines.substring(0, cm.Offset)
                 // + cm.Value + FileLines.substring(cm.Offset, FileLines.length());
 
-                if ((sb.length() == FileLines.length())) {
+                if (sb.length() == FileLines.length()) {
                     Console.warn(FileName + ": Unable to insert @" + cm.Offset + ": " + cm.Value);
                     success = false;
                 }

--- a/src/main/java/org/cf/resequencer/sequence/ApkFile.java
+++ b/src/main/java/org/cf/resequencer/sequence/ApkFile.java
@@ -132,7 +132,7 @@ public class ApkFile extends java.io.File {
      * @return true if Apk has been compiled, false otherwise
      */
     public boolean apkIsCompiled() {
-        return ((ClassesDex != null) && (ClassesDex.length() > 0));
+        return (ClassesDex != null) && (ClassesDex.length() > 0);
     }
 
     /**
@@ -140,7 +140,7 @@ public class ApkFile extends java.io.File {
      * @return true if Apk has been decompiled, false otherwise
      */
     public boolean apkIsDecompiled() {
-        return (new File(DumpDir).exists());
+        return new File(DumpDir).exists();
     }
 
     /**
@@ -149,7 +149,7 @@ public class ApkFile extends java.io.File {
      * @return true if constructed with actual Apk file or Apk file set, false otherwise
      */
     public boolean apkHaveApkFile() {
-        return ((ApkPath != null) && new File(ApkPath).exists());
+        return (ApkPath != null) && new File(ApkPath).exists();
     }
 
     /**
@@ -698,7 +698,7 @@ public class ApkFile extends java.io.File {
 
     private static String getXMLTagValue(Node node) {
         Node n = ((Element) node).getChildNodes().item(0);
-        return (n != null ? n.getNodeValue() : "");
+        return n != null ? n.getNodeValue() : "";
     }
 
     /**

--- a/src/main/java/org/cf/resequencer/sequence/Base64.java
+++ b/src/main/java/org/cf/resequencer/sequence/Base64.java
@@ -123,19 +123,19 @@ class Base64 {
 
 		switch ( numSigBytes ) {
 			case 3:
-				destination[destOffset] = alphabet[(inBuff >>> 18)];
+				destination[destOffset] = alphabet[inBuff >>> 18];
 				destination[destOffset + 1] = alphabet[(inBuff >>> 12) & 0x3f];
 				destination[destOffset + 2] = alphabet[(inBuff >>> 6) & 0x3f];
 				destination[destOffset + 3] = alphabet[(inBuff) & 0x3f];
 				return destination;
 			case 2:
-				destination[destOffset] = alphabet[(inBuff >>> 18)];
+				destination[destOffset] = alphabet[inBuff >>> 18];
 				destination[destOffset + 1] = alphabet[(inBuff >>> 12) & 0x3f];
 				destination[destOffset + 2] = alphabet[(inBuff >>> 6) & 0x3f];
 				destination[destOffset + 3] = EQUALS_SIGN;
 				return destination;
 			case 1:
-				destination[destOffset] = alphabet[(inBuff >>> 18)];
+				destination[destOffset] = alphabet[inBuff >>> 18];
 				destination[destOffset + 1] = alphabet[(inBuff >>> 12) & 0x3f];
 				destination[destOffset + 2] = EQUALS_SIGN;
 				destination[destOffset + 3] = EQUALS_SIGN;
@@ -217,7 +217,7 @@ class Base64 {
 							((source[d + off] << 24) >>> 8)
 							| ((source[d + 1 + off] << 24) >>> 16)
 							| ((source[d + 2 + off] << 24) >>> 24);
-			outBuff[e] = alphabet[(inBuff >>> 18)];
+			outBuff[e] = alphabet[inBuff >>> 18];
 			outBuff[e + 1] = alphabet[(inBuff >>> 12) & 0x3f];
 			outBuff[e + 2] = alphabet[(inBuff >>> 6) & 0x3f];
 			outBuff[e + 3] = alphabet[(inBuff) & 0x3f];
@@ -242,7 +242,7 @@ class Base64 {
 			e += 4;
 		}
 
-		assert (e == outBuff.length);
+		assert e == outBuff.length;
 		return outBuff;
 	}
 

--- a/src/main/java/org/cf/resequencer/sequence/SmaliFileFinder.java
+++ b/src/main/java/org/cf/resequencer/sequence/SmaliFileFinder.java
@@ -15,7 +15,7 @@ import org.cf.resequencer.Console;
 class SmaliFilenameFilter implements FilenameFilter {
     @Override
     public boolean accept(File dir, String name) {
-        return (name.endsWith(".smali"));
+        return name.endsWith(".smali");
     }
 }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:UselessParenthesesCheck

Please let me know if you have any questions.

M-Ezzat
