### PR TITLE
squid:S2864 - entrySet() should be iterated when both the key and val…

### DIFF
--- a/src/main/java/org/cf/resequencer/patch/Fingerprint.java
+++ b/src/main/java/org/cf/resequencer/patch/Fingerprint.java
@@ -40,8 +40,8 @@ class Fingerprint implements Cloneable {
         fpClone.RequiredFingerprints.addAll(RequiredFingerprints);
         fpClone.DeletePaths.addAll(DeletePaths);
 
-        for (Integer key : Regions.keySet()) {
-            fpClone.addRegion(Regions.get(key).clone());
+        for (Map.Entry<Integer, Region> integerRegionEntry : Regions.entrySet()) {
+            fpClone.addRegion(integerRegionEntry.getValue().clone());
         }
 
         return fpClone;
@@ -73,8 +73,8 @@ class Fingerprint implements Cloneable {
         Region region;
 
         Console.debug("Searching for " + FingerprintName + " in " + smaliFile, 2);
-        for (Integer key : Regions.keySet()) {
-            region = Regions.get(key);
+        for (Map.Entry<Integer, Region> integerRegionEntry : Regions.entrySet()) {
+            region = integerRegionEntry.getValue();
             Console.debug("  region: " + region, 3);
 
             // region may match multiple times

--- a/src/main/java/org/cf/resequencer/patch/FingerprintReader.java
+++ b/src/main/java/org/cf/resequencer/patch/FingerprintReader.java
@@ -652,8 +652,8 @@ public class FingerprintReader {
     }
 
     private void fixOpScriptVars() {
-        for (String fpName : Fingerprints.keySet()) {
-            Fingerprint fp = Fingerprints.get(fpName);
+        for (Map.Entry<String, Fingerprint> stringFingerprintEntry : Fingerprints.entrySet()) {
+            Fingerprint fp = stringFingerprintEntry.getValue();
             for (Integer rKey : fp.Regions.keySet()) {
                 Region r = fp.Regions.get(rKey);
                 for (Operation op : r.OperationList) {
@@ -664,11 +664,11 @@ public class FingerprintReader {
     }
 
     private String replaceScriptVars(String strVal) {
-        for (String key : ScriptVars.keySet()) {
-            String repVal = ScriptVars.get(key);
+        for (Map.Entry<String, String> stringStringEntry : ScriptVars.entrySet()) {
+            String repVal = stringStringEntry.getValue();
             // replaceAll devours backslashes with an unending hunger
             repVal = repVal.replaceAll("\\\\", "\\\\\\\\");
-            String replace = "%!" + Pattern.quote(key) + "%";
+            String replace = "%!" + Pattern.quote(stringStringEntry.getKey()) + "%";
             strVal = strVal.replaceAll(replace, repVal);
         }
 

--- a/src/main/java/org/cf/resequencer/patch/Splicer.java
+++ b/src/main/java/org/cf/resequencer/patch/Splicer.java
@@ -77,11 +77,11 @@ public class Splicer {
                 if (success) {
                     System.out.println(" success.");
                     System.out.println("    Applied:");
-                    for (String fpName : appliedFPs.keySet()) {
-                        String out = "      - " + fpName;
+                    for (Map.Entry<String, Integer> stringIntegerEntry : appliedFPs.entrySet()) {
+                        String out = "      - " + stringIntegerEntry.getKey();
                         // also show number of times it was applied
-                        if (appliedFPs.get(fpName) > 1) {
-                            out += " (" + appliedFPs.get(fpName) + ")";
+                        if (stringIntegerEntry.getValue() > 1) {
+                            out += " (" + stringIntegerEntry.getValue() + ")";
                         }
                         System.out.println(out);
                     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2864 - "entrySet()" should be iterated when both the key and value are needed

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S2864

Please let me know if you have any questions.

M-Ezzat
