### PR TITLE
squid:S3052 - Fields should not be initialized to default values

### DIFF
--- a/src/main/java/org/cf/resequencer/Console.java
+++ b/src/main/java/org/cf/resequencer/Console.java
@@ -15,7 +15,7 @@ import org.apache.commons.io.IOUtils;
  */
 public class Console {
     private static final boolean StackTrace = false;
-    public static int VerboseLevel = 0;
+    public static int VerboseLevel;
     public static String LogFile = "console.log";
 
     public static void msgln() {

--- a/src/main/java/org/cf/resequencer/Options.java
+++ b/src/main/java/org/cf/resequencer/Options.java
@@ -17,27 +17,27 @@ import org.cf.resequencer.patch.SmaliHinter;
 public class Options {
 
     private static final int MaxVerboseLevel = 3;
-    public static int VerboseLevel = 0;
-    public static boolean SkipAssembly = false;
-    public static boolean SkipCleanup = false;
-    public static boolean DecodeResources = false;
-    public static boolean SignOnly = false;
-    public static boolean DetectOnly = false;
-    public static boolean InfoOnly = false;
-    public static boolean AssembleOnly = false;
-    public static boolean AllowOverwrites = false;
-    public static boolean ListFPsOnly = false;
-    public static boolean SkipHints = false;
-    public static int CheckSigsBehavior = 0;
-    public static int GetPIBehavior = 0;
-    public static int SigVerifyBehavior = 0;
-    public static int DeviceIDSpoofType = 0;
+    public static int VerboseLevel;
+    public static boolean SkipAssembly;
+    public static boolean SkipCleanup;
+    public static boolean DecodeResources;
+    public static boolean SignOnly;
+    public static boolean DetectOnly;
+    public static boolean InfoOnly;
+    public static boolean AssembleOnly;
+    public static boolean AllowOverwrites;
+    public static boolean ListFPsOnly;
+    public static boolean SkipHints;
+    public static int CheckSigsBehavior;
+    public static int GetPIBehavior;
+    public static int SigVerifyBehavior;
+    public static int DeviceIDSpoofType;
     public static String DeviceIDSpoof = "";
-    public static int WifiMacSpoofType = 0;
+    public static int WifiMacSpoofType;
     public static String WifiMacSpoof = "";
-    public static int BTMacSpoofType = 0;
+    public static int BTMacSpoofType;
     public static String BTMacSpoof = "";
-    public static int AccountNameSpoofType = 0;
+    public static int AccountNameSpoofType;
     public static String AccountNameSpoof = "";
     public static String NetworkOperatorSpoof = "";
     public static String DeviceModelSpoof = "";
@@ -53,10 +53,10 @@ public class Options {
     public static String AaptPath = "";
     public static String ZipalignPath = "";
     public static String KeyApkPath = "";
-    public static File SignKey = null;
-    public static File SignCert = null;
-    public static String SignPass = null;
-    public static boolean DebugHooks = false;
+    public static File SignKey;
+    public static File SignCert;
+    public static String SignPass;
+    public static boolean DebugHooks;
 
     // returns false if options are not valid
     public static void parseArgs(String[] args) {

--- a/src/main/java/org/cf/resequencer/patch/Fingerprint.java
+++ b/src/main/java/org/cf/resequencer/patch/Fingerprint.java
@@ -22,8 +22,8 @@ class Fingerprint implements Cloneable {
     public Map<Integer, Region> Regions = new HashMap<Integer, Region>();
     public boolean Enabled = true;
     public boolean Notify = true; // notify user when found
-    public boolean FindOnce = false;
-    public boolean DependenciesTraced = false;
+    public boolean FindOnce;
+    public boolean DependenciesTraced;
     public String[] SmaliHooksToInstall;
 
     Fingerprint(String n) {

--- a/src/main/java/org/cf/resequencer/patch/FingerprintReader.java
+++ b/src/main/java/org/cf/resequencer/patch/FingerprintReader.java
@@ -37,9 +37,9 @@ public class FingerprintReader {
                     "name", "type", "afterRegex", "beforeRegex", "insideRegex", "afterOP", "beforeOP", "insideOP",
                     "replaceWhat", "deletePath" };
     private final Map<String, String> ScriptVars;
-    private Fingerprint FP = null;
-    private Region REG = null;
-    private Operation OP = null;
+    private Fingerprint FP;
+    private Region REG;
+    private Operation OP;
     private List<String> ExcludedFPs;
     private List<String> IncludedFPs;
     private String HookResourcePath;

--- a/src/main/java/org/cf/resequencer/patch/SmaliHinter.java
+++ b/src/main/java/org/cf/resequencer/patch/SmaliHinter.java
@@ -19,9 +19,9 @@ import com.memetix.mst.translate.Translate;
  * @author Caleb Fenton
  */
 public class SmaliHinter {
-    public static long HintsAdded = 0;
+    public static long HintsAdded;
 
-    public static boolean ShouldTranslate = false;
+    public static boolean ShouldTranslate;
     private static int TranslateBatchSize = 25;
 
     static private String[] LineArray;

--- a/src/main/java/org/cf/resequencer/patch/SmaliHook.java
+++ b/src/main/java/org/cf/resequencer/patch/SmaliHook.java
@@ -34,7 +34,7 @@ public class SmaliHook {
     /*
      * If a hook is not to be obfuscated, this should be set to true.
      */
-    public boolean ForceNoObfuscation = false;
+    public boolean ForceNoObfuscation;
 
     /*
      * Method of anti-decompile protection for baksmali (defunct) is to use invalid file names in Windows. Retained here

--- a/src/main/java/org/cf/resequencer/sequence/AppInfo.java
+++ b/src/main/java/org/cf/resequencer/sequence/AppInfo.java
@@ -28,7 +28,7 @@ public class AppInfo {
     public String AppVersionName;
     public String AppVersionCode;
     public String AppPackageName;
-    public int AppMinSDK = 0;
+    public int AppMinSDK;
     public String[] SignatureChars;
     public String[] SignatureHashes;
     public String LaunchActivity;
@@ -43,15 +43,15 @@ public class AppInfo {
     public String DexDigestSHA1;
     public long DexChecksumCRC32;
     public long DexChecksumAdler32;
-    public long ZipClassesDexCrc = 0;
-    public long ZipClassesDexSize = 0;
-    public long ZipClassesDexCompressedSize = 0;
+    public long ZipClassesDexCrc;
+    public long ZipClassesDexSize;
+    public long ZipClassesDexCompressedSize;
     public Certificate[] Certificates;
     public long ApkFileSize;
     public long ApkLastModified;
     public long ClassesDexFileSize;
     public long ClassesDexLastModified;
-    public int CertsLoaded = 0;
+    public int CertsLoaded;
     private String mApkPath, mAaptPath;
     private static final Object mSync = new Object();
     private WeakReference<byte[]> mReadBuffer;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S3052 - Fields should not be initialized to default values

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S3052

Please let me know if you have any questions.

M-Ezzat
