### PR TITLE
squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/src/main/java/org/cf/resequencer/Console.java
+++ b/src/main/java/org/cf/resequencer/Console.java
@@ -13,10 +13,14 @@ import org.apache.commons.io.IOUtils;
  * 
  * @author Caleb Fenton
  */
-public class Console {
+public final class Console {
     private static final boolean StackTrace = false;
     public static int VerboseLevel;
     public static String LogFile = "console.log";
+
+    private Console () throws InstantiationException {
+        throw new InstantiationException("This class is not created for instantiation");
+    }
 
     public static void msgln() {
         System.out.println();

--- a/src/main/java/org/cf/resequencer/Main.java
+++ b/src/main/java/org/cf/resequencer/Main.java
@@ -34,7 +34,7 @@ import org.cf.resequencer.sequence.ApkFile.DecodeResOption;
  * 
  * @author Caleb Fenton
  */
-public class Main {
+public final class Main {
 
     public static final String VERSION = "1.1";
     private static final String UPDATED = "Feb 28th, 2016";
@@ -46,6 +46,10 @@ public class Main {
     private static final String MethodStarts = "(?sm)^\\s*\\.(locals|registers) \\d+((\\r)?\\n)+" + "(\\s*\\.parameter( \\\".*?\\\")?((\\r)?\\n)+)*" + "(\\s*\\.annotation.+?\\.end annotation((\\r)?\\n)+)*" + "(\\s*\\.end parameter((\\r)?\\n)+)*" + "(\\s*\\.annotation.+?\\.end annotation((\\r)?\\n)+)*" + "(\\s*\\.prologue((\\r)?\\n)+)?" + "(\\s*\\.line( \\d+)?((\\r)?\\n)+)?" + "(\\s*\\.local .+?((\\r)?\\n)+)?\\s*";
     private static ApkFile myApkFile;
     private static FingerprintReader myReader;
+
+    private Main() throws InstantiationException {
+        throw new InstantiationException("This class is not created for instantiation");
+    }
 
     /**
      * @param args

--- a/src/main/java/org/cf/resequencer/Options.java
+++ b/src/main/java/org/cf/resequencer/Options.java
@@ -14,7 +14,7 @@ import org.cf.resequencer.patch.SmaliHinter;
  * 
  * @author Caleb Fenton
  */
-public class Options {
+public final class Options {
 
     private static final int MaxVerboseLevel = 3;
     public static int VerboseLevel;
@@ -57,6 +57,10 @@ public class Options {
     public static File SignCert;
     public static String SignPass;
     public static boolean DebugHooks;
+
+    private Options() throws InstantiationException {
+        throw new InstantiationException("This class is not created for instantiation");
+    }
 
     // returns false if options are not valid
     public static void parseArgs(String[] args) {

--- a/src/main/java/org/cf/resequencer/patch/SmaliHinter.java
+++ b/src/main/java/org/cf/resequencer/patch/SmaliHinter.java
@@ -18,13 +18,17 @@ import com.memetix.mst.translate.Translate;
  * 
  * @author Caleb Fenton
  */
-public class SmaliHinter {
+public final class SmaliHinter {
     public static long HintsAdded;
 
     public static boolean ShouldTranslate;
     private static int TranslateBatchSize = 25;
 
     static private String[] LineArray;
+
+    private SmaliHinter() throws InstantiationException {
+        throw new InstantiationException("This class is not created for instantiation");
+    }
 
     public static void enableTranslations() {
         // Microsoft Bing API key

--- a/src/main/java/org/cf/resequencer/sequence/ApkSigner.java
+++ b/src/main/java/org/cf/resequencer/sequence/ApkSigner.java
@@ -51,7 +51,7 @@ import sun.security.pkcs.SignerInfo;
 import sun.security.x509.AlgorithmId;
 import sun.security.x509.X500Name;
 
-class ApkSigner {
+final class ApkSigner {
 
     private static final String CERT_SF_NAME = "META-INF/CERT.SF";
     private static final String CERT_RSA_NAME = "META-INF/CERT.RSA";
@@ -59,6 +59,10 @@ class ApkSigner {
     private static final String KEY_PATH = "/keys/key.pk8";
 
     private static final int BUFF_SIZE = 4096;
+
+    private ApkSigner() throws InstantiationException {
+        throw new InstantiationException("This class is not created for instantiation");
+    }
 
     private static class SignatureOutputStream extends FilterOutputStream {
 

--- a/src/main/java/org/cf/resequencer/sequence/CryptoUtils.java
+++ b/src/main/java/org/cf/resequencer/sequence/CryptoUtils.java
@@ -22,7 +22,11 @@ import org.cf.resequencer.Console;
  * 
  * @author Caleb Fenton
  */
-public class CryptoUtils {
+public final class CryptoUtils {
+
+    private CryptoUtils() throws InstantiationException {
+        throw new InstantiationException("This class is not created for instantiation");
+    }
 
     public static long getCRC32Chksum(String path) throws FileNotFoundException, IOException {
         byte[] bytes = new byte[0xFFFF];

--- a/src/main/java/org/cf/resequencer/sequence/SmaliFileFinder.java
+++ b/src/main/java/org/cf/resequencer/sequence/SmaliFileFinder.java
@@ -24,7 +24,12 @@ class SmaliFilenameFilter implements FilenameFilter {
  * 
  * @author Caleb Fenton
  */
-public class SmaliFileFinder {
+public final class SmaliFileFinder {
+
+    private SmaliFileFinder() throws InstantiationException {
+        throw new InstantiationException("This class is not created for instantiation");
+    }
+
     public static File[] getSmailFiles(File dir) {
         return getSmaliFiles(dir, true);
     }

--- a/src/main/java/org/cf/resequencer/sequence/StringUtils.java
+++ b/src/main/java/org/cf/resequencer/sequence/StringUtils.java
@@ -13,6 +13,10 @@ public class StringUtils {
     public static final String NUMSTR = "0123456789";
     public static final String SPECIALSTR = "~`!@#$%^&*()_+-=[]{}\\|;:'\",<.>/?";
 
+    private StringUtils() throws InstantiationException {
+        throw new InstantiationException("This class is not created for instantiation");
+    }
+
     public static String generateSpecialCharString(int len) {
         return generateString(ALPHASTR + NUMSTR + SPECIALSTR, len);
 

--- a/src/main/java/org/cf/resequencer/sequence/ZipUtils.java
+++ b/src/main/java/org/cf/resequencer/sequence/ZipUtils.java
@@ -17,7 +17,12 @@ import org.cf.resequencer.Console;
  * 
  * @author Caleb Fenton
  */
-public class ZipUtils {
+public final class ZipUtils {
+
+    private ZipUtils() throws InstantiationException {
+        throw new InstantiationException("This class is not created for instantiation");
+    }
+
     private static File renameZipToTemp(File zipFile) throws IOException {
         File tempFile = File.createTempFile("zipapk", null);
         tempFile.delete();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - Utility classes should not have public constructors

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1118

Please let me know if you have any questions.

M-Ezzat
