### PR TITLE
squid:S1943 - Classes and methods that rely on the default system enc…

### DIFF
--- a/src/main/java/org/cf/resequencer/Console.java
+++ b/src/main/java/org/cf/resequencer/Console.java
@@ -4,6 +4,7 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
 import org.apache.commons.io.FileUtils;
@@ -91,7 +92,7 @@ public class Console {
         try {
             Process child = Runtime.getRuntime().exec(cmd);
 
-            BufferedReader stdInput = new BufferedReader(new InputStreamReader(child.getInputStream()));
+            BufferedReader stdInput = new BufferedReader(new InputStreamReader(child.getInputStream(), StandardCharsets.UTF_8));
 
             String s;
             while ((s = stdInput.readLine()) != null) {

--- a/src/main/java/org/cf/resequencer/sequence/Base64.java
+++ b/src/main/java/org/cf/resequencer/sequence/Base64.java
@@ -1,5 +1,7 @@
 package org.cf.resequencer.sequence;
 
+import java.nio.charset.StandardCharsets;
+
 /**
  * Base64 converter class. This code is not a full-blown MIME encoder;
  * it simply converts binary data to base64 data and back.
@@ -183,7 +185,7 @@ class Base64 {
 			outLen -= 1;
 		}
 
-		return new String(outBuff, 0, outLen);
+		return new String(outBuff, 0, outLen, StandardCharsets.UTF_8);
 	}
 
 	/**
@@ -317,7 +319,7 @@ class Base64 {
 	 * @since 1.4
 	 */
 	protected static byte[] decode(String s) throws Exception {
-		byte[] bytes = s.getBytes();
+		byte[] bytes = s.getBytes(StandardCharsets.UTF_8);
 		return decode(bytes, 0, bytes.length);
 	}
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1943 - Classes and methods that rely on the default system encoding should not be used

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1943

Please let me know if you have any questions.

M-Ezzat
